### PR TITLE
20221227 3 why install grub in swap partition

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -78,7 +78,7 @@ APU/APU2にUSBメモリからインストールするためのISOイメージを
 
     $ make download
     $ make init
-    $ make setup-apu
+    $ make setup-isolinux
 
     $ ln -fs user-data.mbr config/user-data
     $ make setup

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To create an ISO image for installation on the APU/APU2 from a USB stick, please
 
     $ make download
     $ make init
-    $ make setup-apu
+    $ make setup-isolinux
 
     $ ln -fs user-data.mbr config/user-data
     $ make setup

--- a/config/user-data.efi
+++ b/config/user-data.efi
@@ -10,9 +10,6 @@ autoinstall:
   storage:
     swap:
       size: 0
-    grub:
-      install_devices:
-        - partition-1
     config:
       - id: root-ssd
         type: disk

--- a/config/user-data.mbr
+++ b/config/user-data.mbr
@@ -10,9 +10,6 @@ autoinstall:
   storage:
     swap:
       size: 0
-    grub:
-      install_devices:
-        - partition-2
     config:
       - id: root-ssd
         type: disk


### PR DESCRIPTION
After the investigation, I found that the install_devices section is completely useless.

These changes against user-config.{mbr,efi} files is able to work without error in my test environment.
